### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.jmailen.gradle.kotlinter.tasks.*
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.20'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.21'
     id 'org.jetbrains.dokka' version '1.4.32'
     id 'maven-publish'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     // Use the Kotlin JDK standard library.
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7'
     // Use the Kotlin coroutines library.
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.5.0-native-mt'
+    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.5.1'
     // Use the Kotlin test library.
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test'
     // Use the Kotlin JUnit integration.

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     //Jackson
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.3'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.4'
 
     //FlexMark
     implementation group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.62.2'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
 
     //Jackson
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.4'
 
     //FlexMark

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.jmailen.gradle.kotlinter.tasks.*
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.5.21'
-    id 'org.jetbrains.dokka' version '1.4.32'
+    id 'org.jetbrains.dokka' version '1.5.0'
     id 'maven-publish'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'signing'


### PR DESCRIPTION
- Bump kotlinx-coroutines-core from 1.5.0-native-mt to 1.5.1 
- Bump org.jetbrains.kotlin.jvm from 1.5.20 to 1.5.21
- Bump org.jetbrains.dokka from 1.4.32 to 1.5.0
- Bump jackson-core from 2.12.3 to 2.12.4
- Bump jackson-databind from 2.12.3 to 2.12.4