### PR TITLE
fix: Add type and app_id params in `DCConList`

### DIFF
--- a/src/main/kotlin/be/zvz/kotlininside/api/dccon/DCConList.kt
+++ b/src/main/kotlin/be/zvz/kotlininside/api/dccon/DCConList.kt
@@ -18,6 +18,8 @@ class DCConList(
 
     fun request(): ListResult {
         val option = Request.getDefaultOption()
+            .addMultipartParameter("type", "list")
+            .addMultipartParameter("app_id", KotlinInside.getInstance().auth.getAppId())
 
         if (session.user is LoginUser) {
             option.addMultipartParameter("user_id", session.detail!!.userId)


### PR DESCRIPTION
Addresses https://github.com/organization/KotlinInside/issues/282#issuecomment-1767641691
해당 코드 추가 후 정상 작동 됩니다.

별개로 `dccon.php`의 타입은 `list, recent, insert, package_detail, buy_dccon, setting, setting_save` 가 존재합니다.